### PR TITLE
Docker 17.09

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -11,6 +11,9 @@ dockercfg_test:
     path: ./dockercfg-generator
     dockerfile_path: Dockerfile.test
 dockercfg_test_generator:
-  image: codeship/dockercfg-generator
+  build:
+    image: codeshipdeploy/codeship-testing
+    path: ./dockercfg-generator
+    dockerfile_path: Dockerfile.test
   add_docker: true
   encrypted_env_file: docker.env.encrypted

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -12,8 +12,8 @@ dockercfg_test:
     dockerfile_path: Dockerfile.test
 dockercfg_test_generator:
   build:
-    image: codeshipdeploy/codeship-testing
+    image: codeship/dockercfg-generator
     path: ./dockercfg-generator
-    dockerfile_path: Dockerfile.test
+    dockerfile_path: Dockerfile
   add_docker: true
   encrypted_env_file: docker.env.encrypted

--- a/dockercfg-generator/Dockerfile
+++ b/dockercfg-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.07
+FROM docker:17.09
 LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 COPY docker_creds.sh /bin


### PR DESCRIPTION
Update the `dockercfg-generator` to use Docker 17.09, as a preparation to upgrade the Docker version on Codeship Pro as well.

references codeship/jet-base-ami#104