### PR TITLE
Use --password-stdin when logging in to remove login over CLI warning

### DIFF
--- a/dockercfg-generator/docker_creds.sh
+++ b/dockercfg-generator/docker_creds.sh
@@ -8,7 +8,7 @@ set -e
 
 # Logging into the Docker registry
 echo "Logging into registry at ${DOCKER_REGISTRY}"
-docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}" "${DOCKER_REGISTRY}"
+echo ${DOCKER_PASSWORD} | docker login --username "$DOCKER_USERNAME" --password-stdin "${DOCKER_REGISTRY}"
 
 # writing docker creds to desired path
 echo "Writing Docker creds to $1"


### PR DESCRIPTION
This PR supersedes #7 to allow running a Codeship build.