### PR TITLE
Update ssh_helper.sh

### DIFF
--- a/ssh-helper/ssh_helper.sh
+++ b/ssh-helper/ssh_helper.sh
@@ -15,7 +15,7 @@ case "${ACTION}" in
 		;;
 	write)
 		mkdir -p "${BASE_FOLDER}/.ssh/"
-		printf "${PRIVATE_SSH_KEY}" >> "${BASE_FOLDER}/.ssh/id_rsa"
+		printf "${PRIVATE_SSH_KEY}\n" >> "${BASE_FOLDER}/.ssh/id_rsa"
 		;;
 	*)
 		echo "Usage: $0 {generate|prepare|write}"


### PR DESCRIPTION
Repeat `jet steps` can cause invalid key issues as subsequent keys will append to last line of previous key.